### PR TITLE
Remove call to crypto.GenerateKeyPair which overwrote organisation key pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,50 +111,9 @@ You will need to restart your Nuts nodes to enable these changes.
 ### Adding to the Nuts register
 
 If you want to allow the applications to find each other and exchange data, you
-will have to add them to the Nuts registry. Again, if you followed
-[Setup a local Nuts network](https://nuts-documentation.readthedocs.io/en/latest/pages/getting_started/local_network.html#setup-a-local-nuts-network),
-you can find your registry in `nuts-network-local/config/registry`.
-
-#### 1. Add the organisations
-
-To make this process easier the applications will output their registry
-information on startup. Add that information to your registry's
-`organisations.json`.
-
-#### 2. Add the endpoints
-
-You can add the locations of the APIs to the `endpoints.json` file as endpoints
-of the type `urn:oid:1.3.6.1.4.1.54851.2:demo-ehr`. Also, each Nuts node that
-can receive consent needs an endpoint of the type `urn:nuts:endpoint:consent`.
-
-So for each application add this endpoint to `endpoints.json`:
-
-```json
-{
-  "endpointType": "urn:oid:1.3.6.1.4.1.54851.2:demo-ehr",
-  "identifier": "0e906b06-db48-452c-bb61-559f239a06ca",
-  "status": "active",
-  "version": "0.1.0",
-  "URL": "http://localhost:8000/external/patient"
-}
-```
-
-Make sure you give each one a unique identifier and have it point to the right
-URL. Also, make sure both Nuts nodes have a consent endpoint (should be okay if
-you're using `nuts-network-local`).
-
-#### 3. Connect the endpoints to organisations
-
-Connect your endpoints to organizations in the `endpoint_organizations.json`
-file like this:
-
-```json
-{
-  "status": "active",
-  "organization": "urn:oid:2.16.840.1.113883.2.4.6.1:12345678",
-  "endpoint": "0e906b06-db48-452c-bb61-559f239a06ca"
-}
-```
+will have to add them to the Nuts registry.
+Refer to the [Registry Administration documentation](https://nuts-documentation.readthedocs.io/en/latest/pages/administration/registry.html)
+for how to achieve this.
 
 Make sure you add two entries for each organisation, one for the API and one for
 the Nuts node consent endpoint.

--- a/index.js
+++ b/index.js
@@ -13,28 +13,27 @@ const externalAPI = require('./api/external')
 const ssoHandler = require('./api/sso')
 const eventAPI = require('./api/events')
 const stateAPI = require('./api/state')
-const { crypto } = require('./resources/nuts-node')
 
 // Run server
 Logger.log(`Starting server at port ${config.server.port}`)
 
 app.use((req, res, next) => {
-  Logger.log(`Received request for ${config.organisation.name}:${config.server.port}${req.url}`, req.headers['x-forwarded-for'] || req.connection.remoteAddress)
-  next()
+    Logger.log(`Received request for ${config.organisation.name}:${config.server.port}${req.url}`, req.headers['x-forwarded-for'] || req.connection.remoteAddress)
+    next()
 })
 
 // Use Redis for session persistence.
 // Remove the following 2 lines and the 'store' property if you prefer an in-memory store.
 const RedisStore = require('connect-redis')(session)
 const redisServer = process.env.REDIS_SERVER_ADDRESS || 'localhost'
-const redisClient = redis.createClient({ host: redisServer })
+const redisClient = redis.createClient({host: redisServer})
 redisClient.on('error', Logger.error)
 app.use(session({
-  store: new RedisStore({ client: redisClient, prefix: `session-${config.organisation.agb}:` }),
-  secret: config.server.sessionSecret,
-  resave: false,
-  name: `session-${config.organisation.agb}`,
-  saveUninitialized: false
+    store: new RedisStore({client: redisClient, prefix: `session-${config.organisation.agb}:`}),
+    secret: config.server.sessionSecret,
+    resave: false,
+    name: `session-${config.organisation.agb}`,
+    saveUninitialized: false
 }))
 
 app.use(express.static('public'))
@@ -49,33 +48,4 @@ app.use('/', stateAPI)
 eventAPI(io) // Mount events API using socket.io
 
 server.listen(config.server.port, () =>
-  Logger.log(`Server is listening on port ${config.server.port}`))
-
-// Register our organisation with the Nuts node on startup
-
-Logger.log(`Registering our organisation ${config.organisation.name}`)
-
-crypto.getPublicKey(config.organisation.agb)
-  .then(() => Logger.log('Organisation already registered'))
-  .catch(e => {
-    if (!e.response || e.response.status !== 404)
-      return Logger.error(`Error registering organisation, is your Nuts node up? ${e}`);
-
-    crypto.generateKeyPair(config.organisation.agb)
-      .then(pubKey => {
-        const exampleVendorClaimEvent = {
-          type: 'VendorClaimEvent',
-          payload: {
-            vendorIdentifier: '',
-            orgName: config.organisation.name,
-            orgIdentifier: `urn:oid:2.16.840.1.113883.2.4.6.1:${config.organisation.agb}`,
-            orgKeys: [pubKey]
-          }
-        }
-
-        Logger.log(`Registered! Public key for copy'n'pastin:\n${JSON.stringify(exampleVendorClaimEvent)}`)
-      })
-      .catch(e => {
-        Logger.error('Error registering organisation, is your Nuts node up?', e)
-      })
-  })
+    Logger.log(`Server is listening on port ${config.server.port}`))

--- a/resources/nuts-node/crypto.js
+++ b/resources/nuts-node/crypto.js
@@ -5,6 +5,5 @@ const call = require('./open-api-helper').call({
 })
 
 module.exports = {
-  generateKeyPair: async (agb) => call('generateKeyPair', `urn:oid:2.16.840.1.113883.2.4.6.1:${agb}`),
   getPublicKey: async (agb) => call('publicKey', `urn:oid:2.16.840.1.113883.2.4.6.1:${agb}`)
 }


### PR DESCRIPTION
This isn't even possible in the upcoming 0.15 release (which requires `overwrite=true` if you want to overwrite the existing key).

Looks like the feature was there to register the health care organisation if it wasn't found during startup. The means of registration (generating a key pair) is wrong anyways (might've worked in distant past) since it doesn't actually register the organisation in the registry. This also (always) failed in `nuts-network-local` since it checked the existance of the organisation before registration right after starting the service, by querying the Registry in the Nuts node, which wasn't started by then so it would always fail.

If this is still a feasible feature (auto-registration of organisation) much more work needs to be done (e.g. registering vendor first).

As it's broken and not very easy to fix, I'll remove it altogether for now.