### PR TITLE
Show error in UI when password login fails

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,12 +49,12 @@ func (w Wrapper) AuthenticateWithPassword(ctx echo.Context) error {
 func (w Wrapper) AuthenticateWithIRMA(ctx echo.Context) error {
 	req := domain.IRMAAuthenticationRequest{}
 	if err := ctx.Bind(&req); err != nil {
-		return ctx.String(http.StatusBadRequest, err.Error())
+		return ctx.JSON(http.StatusBadRequest, errorResponse{err})
 	}
 
 	customer, err := w.Repository.FindByID(req.CustomerID)
 	if err != nil {
-		return ctx.String(http.StatusInternalServerError, err.Error())
+		return ctx.JSON(http.StatusInternalServerError, errorResponse{err})
 	}
 
 	// forward to node
@@ -66,7 +66,7 @@ func (w Wrapper) AuthenticateWithIRMA(ctx echo.Context) error {
 	// convert to map so echo rendering doesn't escape double quotes
 	j := map[string]interface{}{}
 	json.Unmarshal(bytes, &j)
-	return ctx.JSON(200, j)
+	return ctx.JSON(http.StatusOK, j)
 }
 
 func (w Wrapper) GetIRMAAuthenticationResult(ctx echo.Context, sessionToken string) error {
@@ -79,7 +79,7 @@ func (w Wrapper) GetIRMAAuthenticationResult(ctx echo.Context, sessionToken stri
 	base64String := base64.StdEncoding.EncodeToString(bytes)
 	token := w.Auth.StoreVP(base64String)
 	writeSession(ctx, token)
-	return ctx.JSON(200, domain.SessionToken{
+	return ctx.JSON(http.StatusOK, domain.SessionToken{
 		Token: token,
 	})
 }
@@ -87,7 +87,7 @@ func (w Wrapper) GetIRMAAuthenticationResult(ctx echo.Context, sessionToken stri
 func (w Wrapper) ListCustomers(ctx echo.Context) error {
 	customers, err := w.Repository.All()
 	if err != nil {
-		return echo.NewHTTPError(500, err.Error())
+		return ctx.JSON(http.StatusInternalServerError, errorResponse{err})
 	}
 	return ctx.JSON(http.StatusOK, customers)
 }

--- a/web/src/components/auth/PasswordAuthentication.vue
+++ b/web/src/components/auth/PasswordAuthentication.vue
@@ -64,12 +64,13 @@ export default {
     },
     login() {
       this.$api.post('web/auth/passwd', this.credentials)
-          .then(responseData => {
+          .then(() => {
             console.log("Password authentication successful")
             this.redirectAfterLogin()
           })
           .catch(response => {
-            this.loginError = response.statusText
+            console.log("Password authentication failed: " + response)
+            this.loginError = response
           })
     },
   },


### PR DESCRIPTION
This PR fixes 2 problems:

- Return 403 instead of 401, since 401 is handled as "client is unauthorized and needs to be redirected to login page"
- Return authentication errors as JSON (instead of plain text) so they can be parsed and shown in the UI (will fix this for other errors after this PR)