### PR TITLE
Enable CGO in Dockerbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ FROM golang:1.16-alpine as backend-builder
 ARG TARGETARCH
 ARG TARGETOS
 
+RUN apk update \
+ && apk add --no-cache \
+            gcc=10.2.1_pre1-r3
+
 ENV GO111MODULE on
 ENV GOPATH /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN go mod download && go mod verify
 
 COPY . .
 COPY --from=frontend-builder /app/web/dist /app/web/dist
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s" -o /app/nuts-demo-ehr
+RUN CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s" -o /app/nuts-demo-ehr
 
 #
 # Runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ARG TARGETOS
 
 RUN apk update \
  && apk add --no-cache \
-            gcc=10.2.1_pre1-r3
+            gcc=10.3.1_git20210424-r2 \
+            musl-dev
 
 ENV GO111MODULE on
 ENV GOPATH /


### PR DESCRIPTION
Should fix:
```panic: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub```