### PR TITLE
Create specific endpoint for Docker healthcheck to reduce spam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,6 @@ RUN mkdir /app && cd /app
 WORKDIR /app
 COPY --from=backend-builder /app/nuts-demo-ehr .
 HEALTHCHECK --start-period=5s --timeout=5s --interval=5s \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:1304/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:1304/status || exit 1
 EXPOSE 1304
 ENTRYPOINT ["/app/nuts-demo-ehr"]


### PR DESCRIPTION
Endpoint can be excluded from Echo access log, to reduce spam in the server log.