### PR TITLE
Filter FHIR resources when querying inbox

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -7,4 +7,7 @@
 * eOverdracht Bolt states:
   * Het endpoint waar de notificatie heen moet is een combinatie van het base endpoint en het relatieve pad zoals gedefinieerd in het TO van Nictiz.
   * The relative path isn't defined in the Nictiz spec
-  
+
+# eOverdracht Bolt Specification Gaps
+* The Bolt states: "Omdat het security token geen gebruikersinformatie bevat, mogen er nooit persoonsgegevens meegestuurd worden in de Task."
+  * But this is allowed by the Nictiz specification (but optional)?

--- a/api/inbox.go
+++ b/api/inbox.go
@@ -13,8 +13,8 @@ func (w Wrapper) GetInboxInfo(ctx echo.Context) error {
 }
 
 func (w Wrapper) GetInbox(ctx echo.Context) error {
-	customerID := w.getCustomerID(ctx)
-	entries, err := w.Inbox.List(ctx.Request().Context(), customerID)
+	customer := w.getCustomer(ctx)
+	entries, err := w.Inbox.List(ctx.Request().Context(), customer)
 	if err != nil {
 		return err
 	}

--- a/api/patient.go
+++ b/api/patient.go
@@ -78,16 +78,23 @@ func (w Wrapper) GetPatient(ctx echo.Context, patientID string) error {
 }
 
 func (w Wrapper) getCustomerID(ctx echo.Context) string {
+	customer := w.getCustomer(ctx)
+	if customer == nil {
+		return ""
+	}
+	return customer.Id
+}
+
+func (w Wrapper) getCustomer(ctx echo.Context) *domain.Customer {
 	cid, ok := ctx.Get(CustomerID).(string)
 	if !ok {
-		return ""
+		return nil
 	}
 	customer, _ := w.CustomerRepository.FindByID(cid)
 	if customer.Id != cid {
-		return ""
+		return nil
 	}
-
-	return customer.Id
+	return customer
 }
 
 func (w Wrapper) getCustomerDID(ctx echo.Context) *string {

--- a/domain/fhir/util.go
+++ b/domain/fhir/util.go
@@ -12,6 +12,16 @@ const SnomedNursingHandoffCode = "371535009"
 const SnomedTransferCode = "308292007"
 const NutsCodingSystem = "http://nuts.nl"
 
+func Filter(resources []gjson.Result, predicate func(resource gjson.Result) bool) []gjson.Result {
+	var result []gjson.Result
+	for _, resource := range resources {
+		if predicate(resource) {
+			result = append(result, resource)
+		}
+	}
+	return result
+}
+
 func FilterResources(resources []gjson.Result, codingSystem CodingSystem, code string) []gjson.Result {
 	var result []gjson.Result
 	for _, resource := range resources {

--- a/domain/fhir/util.go
+++ b/domain/fhir/util.go
@@ -10,6 +10,7 @@ type CodingSystem string
 const SnomedCodingSystem CodingSystem = "http://snomed.info/sct"
 const SnomedNursingHandoffCode = "371535009"
 const SnomedTransferCode = "308292007"
+const NutsCodingSystem = "http://nuts.nl"
 
 func FilterResources(resources []gjson.Result, codingSystem CodingSystem, code string) []gjson.Result {
 	var result []gjson.Result

--- a/domain/inbox/repository_test.go
+++ b/domain/inbox/repository_test.go
@@ -181,7 +181,7 @@ const tasks = `
 }`
 
 func Test_getInboxEntries(t *testing.T) {
-	entries, _ := getInboxEntries(tasks, nil)
+	entries, _ := getInboxEntries(tasks, nil, "")
 	if !assert.Len(t, entries, 1) {
 		return
 	}

--- a/domain/inbox/service.go
+++ b/domain/inbox/service.go
@@ -67,7 +67,6 @@ func getInboxEntries(client fhir.Client, sender domain.Organization) ([]domain.I
 	}
 	var results []domain.InboxEntry
 	for _, resource := range tasks {
-		println(resource.String())
 		results = append(results, domain.InboxEntry{
 			Title:  resource.Get("code.coding.0.display").String(),
 			Sender: sender,


### PR DESCRIPTION
- Move task filtering (only patient transfers) to query param
- Filter tasks based on current care organization's DID, so only tasks for the local EHR are shown.