### PR TITLE
Transfer request details

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -769,6 +769,10 @@ components:
           type: string
     TransferRequest:
       description: Incoming request from another care organization to transfer a patient.
+      required:
+        - sender
+        - transferDate
+        - description
       properties:
         sender:
           $ref: '#/components/schemas/Organization'
@@ -776,6 +780,9 @@ components:
           description: Requested transfer date.
           type: string
           format: date
+        description:
+          description: Descriptive text of the transfer request
+          type: string
 
     Dossier:
       required:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -333,7 +333,33 @@ paths:
         404:
           description: transfer or negotiation not found.
         400:
-          description: Invalid request. State transition might be illigal.
+          description: Invalid request. State transition might be illegal.
+
+  /private/transfer-request/{requestorDID}/{fhirTaskID}:
+    parameters:
+      - name: requestorDID
+        in: path
+        description: DID of the care organizaton that requests the transfer.
+        required: true
+        schema:
+          type: string
+      - name: fhirTaskID
+        in: path
+        description: ID of the FHIR transfer task at the care organization that requests the transfer.
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getTransferRequest
+      description: Retrieves a transfer request from another care organization.
+      responses:
+        200:
+          description: Transfer request found and returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TransferRequest"
+
   /private/patients:
     get:
       parameters:
@@ -741,6 +767,16 @@ components:
           $ref: '#/components/schemas/ObjectID'
         name:
           type: string
+    TransferRequest:
+      description: Incoming request from another care organization to transfer a patient.
+      properties:
+        sender:
+          $ref: '#/components/schemas/Organization'
+        transferDate:
+          description: Requested transfer date.
+          type: string
+          format: date
+
     Dossier:
       required:
         - id
@@ -765,6 +801,8 @@ components:
         - title
         - sender
         - date
+        - type
+        - resourceID
       properties:
         title:
           description: Descriptive title.
@@ -775,6 +813,14 @@ components:
           description: Date/time of the entry.
           type: string
           format: datetime
+        type:
+          description: Type of the entry
+          type: string
+          enum:
+            - transferRequest
+        resourceID:
+          description: ID that should be used when retrieving the source document of the inbox entry, e.g. a transfer request.
+          type: string
 
   securitySchemes:
     bearerAuth:

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -42,7 +42,7 @@ func (w Wrapper) GetTransfer(ctx echo.Context, transferID string) error {
 }
 
 func (w Wrapper) GetTransferRequest(ctx echo.Context, requestorDID string, fhirTaskID string) error {
-	transferRequest, err := w.TransferService.GetTransferRequest(requestorDID, fhirTaskID)
+	transferRequest, err := w.TransferService.GetTransferRequest(ctx.Request().Context(), requestorDID, fhirTaskID)
 	if err != nil {
 		return err
 	}

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -41,6 +41,14 @@ func (w Wrapper) GetTransfer(ctx echo.Context, transferID string) error {
 	return ctx.JSON(http.StatusOK, transfer)
 }
 
+func (w Wrapper) GetTransferRequest(ctx echo.Context, requestorDID string, fhirTaskID string) error {
+	transferRequest, err := w.TransferService.GetTransferRequest(requestorDID, fhirTaskID)
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, transferRequest)
+}
+
 func (w Wrapper) UpdateTransfer(ctx echo.Context, transferID string) error {
 	updateRequest := &domain.TransferProperties{}
 	err := ctx.Bind(updateRequest)

--- a/domain/fhir/client.go
+++ b/domain/fhir/client.go
@@ -13,7 +13,7 @@ func NewClient(baseURL string) Client {
 
 type Client interface {
 	GetResources(path string, params map[string]string) ([]gjson.Result, error)
-	GetResource(path string) ([]gjson.Result, error)
+	GetResource(path string) (gjson.Result, error)
 }
 
 type httpClient struct {
@@ -28,9 +28,8 @@ func (h httpClient) GetResources(path string, params map[string]string) ([]gjson
 	return nil, err
 }
 
-func (h httpClient) GetResource(path string) ([]gjson.Result, error) {
-	resource, err := h.getResource(path, nil)
-	return resource.Array(), err
+func (h httpClient) GetResource(path string) (gjson.Result, error) {
+	return h.getResource(path, nil)
 }
 
 func (h httpClient) getResource(path string, params map[string]string) (gjson.Result, error) {

--- a/domain/generated_types.go
+++ b/domain/generated_types.go
@@ -11,6 +11,11 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for InboxEntryType.
+const (
+	InboxEntryTypeTransferRequest InboxEntryType = "transferRequest"
+)
+
 // Defines values for PatientPropertiesGender.
 const (
 	PatientPropertiesGenderFemale PatientPropertiesGender = "female"
@@ -131,12 +136,21 @@ type InboxEntry struct {
 	// Date/time of the entry.
 	Date string `json:"date"`
 
+	// ID that should be used when retrieving the source document of the inbox entry, e.g. a transfer request.
+	ResourceID string `json:"resourceID"`
+
 	// A care organization available through the Nuts Network to exchange information.
 	Sender Organization `json:"sender"`
 
 	// Descriptive title.
 	Title string `json:"title"`
+
+	// Type of the entry
+	Type InboxEntryType `json:"type"`
 }
+
+// Type of the entry
+type InboxEntryType string
 
 // InboxInfo defines model for InboxInfo.
 type InboxInfo struct {
@@ -276,6 +290,16 @@ type TransferProperties struct {
 
 	// Transfer date as proposed by the sending XIS. It is populated/updated by the last negotiation that was started.
 	TransferDate openapi_types.Date `json:"transferDate"`
+}
+
+// Incoming request from another care organization to transfer a patient.
+type TransferRequest struct {
+
+	// A care organization available through the Nuts Network to exchange information.
+	Sender *Organization `json:"sender,omitempty"`
+
+	// Requested transfer date.
+	TransferDate *openapi_types.Date `json:"transferDate,omitempty"`
 }
 
 // SetCustomerJSONBody defines parameters for SetCustomer.

--- a/domain/generated_types.go
+++ b/domain/generated_types.go
@@ -295,11 +295,14 @@ type TransferProperties struct {
 // Incoming request from another care organization to transfer a patient.
 type TransferRequest struct {
 
+	// Descriptive text of the transfer request
+	Description string `json:"description"`
+
 	// A care organization available through the Nuts Network to exchange information.
-	Sender *Organization `json:"sender,omitempty"`
+	Sender Organization `json:"sender"`
 
 	// Requested transfer date.
-	TransferDate *openapi_types.Date `json:"transferDate,omitempty"`
+	TransferDate openapi_types.Date `json:"transferDate"`
 }
 
 // SetCustomerJSONBody defines parameters for SetCustomer.

--- a/web/src/ehr/Inbox.vue
+++ b/web/src/ehr/Inbox.vue
@@ -13,7 +13,8 @@
       </thead>
       <tbody>
       <tr class="hover:bg-gray-100 cursor-pointer"
-          v-for="item in items">
+          v-for="item in items"
+          @click="$router.push({name: 'ehr.transferRequest.show', params: {requestorDID: item.sender.did, fhirTaskID: item.resourceID}})">
         <td>
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/web/src/ehr/transfer/TransferRequest.vue
+++ b/web/src/ehr/transfer/TransferRequest.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <h1 class="page-title">Transfer Request</h1>
+
+    <div class="mt-4" v-if="transfer">
+      <div class="bg-gray-50 font-bold">Requesting Care Organization</div>
+      <div>
+        {{ transfer.sender.name }}, {{ transfer.sender.city }}
+      </div>
+    </div>
+
+    <div class="mt-4" v-if="transfer">
+      <div class="bg-gray-50 font-bold">Transfer date</div>
+      <div>
+        {{ transfer.transferDate }}
+      </div>
+    </div>
+
+    <div class="mt-4" v-if="transfer">
+      <div class="bg-gray-50 font-bold">Condition</div>
+      <div>
+        {{ transfer.condition }}
+      </div>
+    </div>
+
+
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      items: [],
+    }
+  },
+  created() {
+    this.fetchData()
+  },
+  methods: {
+    fetchData() {
+      this.$api.getInbox()
+          .then((response) => this.items = response)
+          .catch(error => this.$status.error(error))
+    }
+  }
+}
+</script>

--- a/web/src/ehr/transfer/TransferRequest.vue
+++ b/web/src/ehr/transfer/TransferRequest.vue
@@ -2,35 +2,33 @@
   <div>
     <h1 class="page-title">Transfer Request</h1>
 
-    <div class="mt-4" v-if="transfer">
+    <div class="mt-4" v-if="transferRequest">
       <div class="bg-gray-50 font-bold">Requesting Care Organization</div>
       <div>
-        {{ transfer.sender.name }}, {{ transfer.sender.city }}
+        {{ transferRequest.sender.name }}, {{ transferRequest.sender.city }}
       </div>
     </div>
 
-    <div class="mt-4" v-if="transfer">
+    <div class="mt-4" v-if="transferRequest">
       <div class="bg-gray-50 font-bold">Transfer date</div>
       <div>
-        {{ transfer.transferDate }}
+        {{ transferRequest.transferDate }}
       </div>
     </div>
 
-    <div class="mt-4" v-if="transfer">
+    <div class="mt-4" v-if="transferRequest">
       <div class="bg-gray-50 font-bold">Condition</div>
       <div>
-        {{ transfer.condition }}
+        {{ transferRequest.description }}
       </div>
     </div>
-
-
   </div>
 </template>
 <script>
 export default {
   data() {
     return {
-      items: [],
+      transferRequest: null,
     }
   },
   created() {
@@ -38,8 +36,8 @@ export default {
   },
   methods: {
     fetchData() {
-      this.$api.getInbox()
-          .then((response) => this.items = response)
+      this.$api.getTransferRequest({requestorDID: this.$route.params.requestorDID, fhirTaskID: this.$route.params.fhirTaskID})
+          .then((transferRequest) => this.transferRequest = transferRequest)
           .catch(error => this.$status.error(error))
     }
   }

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -18,6 +18,7 @@ import EditPatient from "./ehr/patient/EditPatient.vue"
 import NewDossier from "./ehr/patient/dossier/New.vue"
 import NewTransfer from "./ehr/patient/transfer/NewTransfer.vue"
 import EditTransfer from "./ehr/patient/transfer/EditTransfer.vue"
+import TransferRequest from "./ehr/transfer/TransferRequest.vue"
 import Inbox from "./ehr/Inbox.vue"
 import Settings from "./ehr/Settings.vue"
 import Components from "./Components.vue"
@@ -97,6 +98,11 @@ const routes = [
             component: EditTransfer
           },
         ],
+      },
+      {
+        path: 'transfer-request/:requestorDID/:fhirTaskID',
+        name: 'ehr.transferRequest.show',
+        component: TransferRequest
       },
       {
         path: 'inbox',

--- a/web/src/plugins/api-impl.js
+++ b/web/src/plugins/api-impl.js
@@ -134,6 +134,23 @@ function createApi(options) {
           mode,
         });
     },
+    notifyTransferUpdate(parameters) {
+      const params = typeof parameters === 'undefined' ? {} : parameters;
+      let headers = {
+
+      };
+      handleSecurity([{"bearerAuth":[]}]
+          , headers, params, 'notifyTransferUpdate');
+      return fetch(endpoint + basePath + '/external/transfer/notify' + '?' + buildQuery({
+          'taskOwnerDID': params['taskOwnerDID'],
+        })
+
+        , {
+          method: 'POST',
+          headers,
+          mode,
+        });
+    },
     checkSession(parameters) {
       const params = typeof parameters === 'undefined' ? {} : parameters;
       let headers = {
@@ -339,6 +356,20 @@ function createApi(options) {
           mode,
           body: JSON.stringify(params['body']),
 
+        });
+    },
+    getTransferRequest(parameters) {
+      const params = typeof parameters === 'undefined' ? {} : parameters;
+      let headers = {
+
+      };
+      handleSecurity([{"bearerAuth":[]}]
+          , headers, params, 'getTransferRequest');
+      return fetch(endpoint + basePath + '/private/transfer-request/' + params['requestorDID'] + '/' + params['fhirTaskID'] + ''
+        , {
+          method: 'GET',
+          headers,
+          mode,
         });
     },
     cancelTransfer(parameters) {


### PR DESCRIPTION
Adds a detail page for transfer requests. It can be reached by clicking on a received transfer request in the inbox.

It shows hardcoded data, because it needs to be read from the advance notice composition, which isn't there yet.