### PR TITLE
Disable cache when requesting FHIR resources

### DIFF
--- a/domain/fhir/client.go
+++ b/domain/fhir/client.go
@@ -70,7 +70,7 @@ func (h httpClient) ReadOne(ctx context.Context, path string, result interface{}
 }
 
 func (h httpClient) getResource(ctx context.Context, path string, params map[string]string) (gjson.Result, error) {
-	resp, err := h.restClient.R().SetQueryParams(params).SetContext(ctx).Get(h.buildRequestURI(path))
+	resp, err := h.restClient.R().SetQueryParams(params).SetContext(ctx).SetHeader("Cache-Control", "no-cache").Get(h.buildRequestURI(path))
 	if err != nil {
 		return gjson.Result{}, err
 	}


### PR DESCRIPTION
HAPI FHIR server returns a cached result by default, which leads to stale data being showed in the UI (e.g. when a new patient has just been created).

For now we'll just disable caching.