### PR TITLE
Add Elevation UI

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -144,6 +144,49 @@ func (w Wrapper) GetIRMAAuthenticationResult(ctx echo.Context, sessionToken stri
 	return ctx.JSON(200, domain.SessionToken{Token: string(newToken)})
 }
 
+func (w Wrapper) AuthenticateWithDummy(ctx echo.Context) error {
+	customerID, err := w.getCustomerIDFromHeader(ctx)
+	if err != nil {
+		return err
+	}
+	customer, err := w.CustomerRepository.FindByID(customerID)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, errorResponse{err})
+	}
+	bytes, err := w.NutsAuth.CreateDummySession(*customer)
+	if err != nil {
+		return err
+	}
+
+	// convert to map so echo rendering doesn't escape double quotes
+	j := map[string]interface{}{}
+	json.Unmarshal(bytes, &j)
+	return ctx.JSON(http.StatusOK, j)
+}
+
+func (w Wrapper) GetDummyAuthenticationResult(ctx echo.Context, sessionToken string) error {
+	customerID, err := w.getCustomerIDFromHeader(ctx)
+	if err != nil {
+		return err
+	}
+
+	// forward to node
+	bytes, err := w.NutsAuth.GetDummySessionResult(sessionToken)
+	if err != nil {
+		return err
+	}
+
+	base64String := base64.StdEncoding.EncodeToString(bytes)
+	sessionID := w.APIAuth.StoreVP(customerID, base64String)
+
+	newToken, err := w.APIAuth.CreateSessionJWT(customerID, sessionID, true)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err)
+	}
+
+	return ctx.JSON(200, domain.SessionToken{Token: string(newToken)})
+}
+
 func (w Wrapper) GetCustomer(ctx echo.Context) error {
 	customerID := ctx.Get(CustomerID)
 

--- a/api/api.go
+++ b/api/api.go
@@ -86,21 +86,8 @@ func (w Wrapper) AuthenticateWithPassword(ctx echo.Context) error {
 	return ctx.JSON(200, domain.SessionToken{Token: string(token)})
 }
 
-func (w Wrapper) getCustomerIDFromHeader(ctx echo.Context) (int, error) {
-	token, err := w.APIAuth.extractJWTFromHeader(ctx)
-	if err != nil {
-		ctx.Echo().Logger.Error(err)
-		return 0, echo.NewHTTPError(http.StatusUnauthorized, err)
-	}
-	rawID, ok := token.Get(CustomerID)
-	if !ok {
-		return 0, echo.NewHTTPError(http.StatusUnauthorized, "missing customerID in token")
-	}
-	return int(rawID.(float64)), nil
-}
-
 func (w Wrapper) AuthenticateWithIRMA(ctx echo.Context) error {
-	customerID, err := w.getCustomerIDFromHeader(ctx)
+	customerID, err := w.APIAuth.GetCustomerIDFromHeader(ctx)
 	if err != nil {
 		return err
 	}
@@ -122,7 +109,7 @@ func (w Wrapper) AuthenticateWithIRMA(ctx echo.Context) error {
 }
 
 func (w Wrapper) GetIRMAAuthenticationResult(ctx echo.Context, sessionToken string) error {
-	customerID, err := w.getCustomerIDFromHeader(ctx)
+	customerID, err := w.APIAuth.GetCustomerIDFromHeader(ctx)
 	if err != nil {
 		return err
 	}
@@ -145,7 +132,7 @@ func (w Wrapper) GetIRMAAuthenticationResult(ctx echo.Context, sessionToken stri
 }
 
 func (w Wrapper) AuthenticateWithDummy(ctx echo.Context) error {
-	customerID, err := w.getCustomerIDFromHeader(ctx)
+	customerID, err := w.APIAuth.GetCustomerIDFromHeader(ctx)
 	if err != nil {
 		return err
 	}
@@ -165,7 +152,7 @@ func (w Wrapper) AuthenticateWithDummy(ctx echo.Context) error {
 }
 
 func (w Wrapper) GetDummyAuthenticationResult(ctx echo.Context, sessionToken string) error {
-	customerID, err := w.getCustomerIDFromHeader(ctx)
+	customerID, err := w.APIAuth.GetCustomerIDFromHeader(ctx)
 	if err != nil {
 		return err
 	}

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -71,6 +71,36 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SessionToken"
+  /auth/dummy:
+    post:
+      description: Create a dummy signing session.
+      operationId: authenticateWithDummy
+      responses:
+        '200':
+          description: A Dummy signing session was succesfully created
+          content:
+            application/json:
+              schema:
+                type: object
+  /auth/dummy/session/{sessionToken}/result:
+    parameters:
+      - name: sessionToken
+        in: path
+        description: Dummy session ID
+        required: true
+        schema:
+          type: string
+    get:
+      description: |
+        After a successful Dummy signing session the resulting token can be fetched using his endpoint.
+      operationId: getDummyAuthenticationResult
+      responses:
+        '200':
+          description: Session result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionToken"
 
   /private:
     get:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -630,14 +630,6 @@ components:
         token:
           type: string
           description: the result from a signing session. It's an updated JWT.
-    IRMAAuthenticationRequest:
-      required:
-        - customerID
-      properties:
-        customerID:
-          description: Internal ID of the customer for which is being logged in
-          type: integer
-          example: 1
     PasswordAuthenticateRequest:
       required:
         - customerID

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -43,16 +43,11 @@ paths:
   # IRMA authentication
   /auth/irma/session:
     post:
+      description: Create an IRMA signing session.
       operationId: authenticateWithIRMA
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/IRMAAuthenticationRequest"
       responses:
         '200':
-          description: A session was succesfully created
+          description: An IRMA signing session was succesfully created
           content:
             application/json:
               schema:
@@ -66,6 +61,8 @@ paths:
         schema:
           type: string
     get:
+      description: |
+        After a successful IRMA signing session the resulting signature can be fetched using his endpoint.
       operationId: getIRMAAuthenticationResult
       responses:
         '200':

--- a/api/auth.go
+++ b/api/auth.go
@@ -87,7 +87,6 @@ func (auth *Auth) JWTHandler(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
 		protectedPaths := []string{
 			"/web/private",
-			"/web/auth/irma",
 		}
 		for _, path := range protectedPaths {
 			if strings.HasPrefix(ctx.Request().RequestURI, path) {

--- a/api/auth.go
+++ b/api/auth.go
@@ -22,6 +22,7 @@ import (
 const MaxSessionAge = time.Hour
 const CustomerID = "cid"
 const SessionID = "sid"
+const Elevated = "elv"
 
 type Auth struct {
 	// sessions maps session identifiers to base64 encoded VPs
@@ -65,12 +66,13 @@ func (auth *Auth) CreateCustomerJWT(customerId int) ([]byte, error) {
 }
 
 // CreateSessionJWT creates a JWT with customer ID and session ID
-func (auth *Auth) CreateSessionJWT(customerId int, session string) ([]byte, error) {
+func (auth *Auth) CreateSessionJWT(customerId int, session string, elevated bool) ([]byte, error) {
 	t := openid.New()
 	t.Set(jwt.IssuedAtKey, time.Now())
 	t.Set(jwt.ExpirationKey, time.Now().Add(MaxSessionAge))
 	t.Set(CustomerID, customerId)
 	t.Set(SessionID, session)
+	t.Set(Elevated, elevated)
 
 	return jwt.Sign(t, jwa.ES256, auth.sessionKey)
 }
@@ -85,6 +87,7 @@ func (auth *Auth) JWTHandler(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
 		protectedPaths := []string{
 			"/web/private",
+			"/web/auth/irma",
 		}
 		for _, path := range protectedPaths {
 			if strings.HasPrefix(ctx.Request().RequestURI, path) {

--- a/api/auth.go
+++ b/api/auth.go
@@ -65,6 +65,20 @@ func (auth *Auth) CreateCustomerJWT(customerId int) ([]byte, error) {
 	return jwt.Sign(t, jwa.ES256, auth.sessionKey)
 }
 
+
+func (auth Auth) GetCustomerIDFromHeader(ctx echo.Context) (int, error) {
+	token, err := auth.extractJWTFromHeader(ctx)
+	if err != nil {
+		ctx.Echo().Logger.Error(err)
+		return 0, echo.NewHTTPError(http.StatusUnauthorized, err)
+	}
+	rawID, ok := token.Get(CustomerID)
+	if !ok {
+		return 0, echo.NewHTTPError(http.StatusUnauthorized, "missing customerID in token")
+	}
+	return int(rawID.(float64)), nil
+}
+
 // CreateSessionJWT creates a JWT with customer ID and session ID
 func (auth *Auth) CreateSessionJWT(customerId int, session string, elevated bool) ([]byte, error) {
 	t := openid.New()

--- a/api/generated.go
+++ b/api/generated.go
@@ -17,6 +17,12 @@ type ServerInterface interface {
 	// (POST /auth)
 	SetCustomer(ctx echo.Context) error
 
+	// (POST /auth/dummy)
+	AuthenticateWithDummy(ctx echo.Context) error
+
+	// (GET /auth/dummy/session/{sessionToken}/result)
+	GetDummyAuthenticationResult(ctx echo.Context, sessionToken string) error
+
 	// (POST /auth/irma/session)
 	AuthenticateWithIRMA(ctx echo.Context) error
 
@@ -112,6 +118,35 @@ func (w *ServerInterfaceWrapper) SetCustomer(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.SetCustomer(ctx)
+	return err
+}
+
+// AuthenticateWithDummy converts echo context to params.
+func (w *ServerInterfaceWrapper) AuthenticateWithDummy(ctx echo.Context) error {
+	var err error
+
+	ctx.Set(BearerAuthScopes, []string{""})
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.AuthenticateWithDummy(ctx)
+	return err
+}
+
+// GetDummyAuthenticationResult converts echo context to params.
+func (w *ServerInterfaceWrapper) GetDummyAuthenticationResult(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "sessionToken" -------------
+	var sessionToken string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "sessionToken", runtime.ParamLocationPath, ctx.Param("sessionToken"), &sessionToken)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter sessionToken: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{""})
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetDummyAuthenticationResult(ctx, sessionToken)
 	return err
 }
 
@@ -592,6 +627,8 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	}
 
 	router.POST(baseURL+"/auth", wrapper.SetCustomer)
+	router.POST(baseURL+"/auth/dummy", wrapper.AuthenticateWithDummy)
+	router.GET(baseURL+"/auth/dummy/session/:sessionToken/result", wrapper.GetDummyAuthenticationResult)
 	router.POST(baseURL+"/auth/irma/session", wrapper.AuthenticateWithIRMA)
 	router.GET(baseURL+"/auth/irma/session/:sessionToken/result", wrapper.GetIRMAAuthenticationResult)
 	router.POST(baseURL+"/auth/passwd", wrapper.AuthenticateWithPassword)

--- a/domain/generated_types.go
+++ b/domain/generated_types.go
@@ -112,12 +112,6 @@ type Dossier struct {
 	PatientID ObjectID `json:"patientID"`
 }
 
-// IRMAAuthenticationRequest defines model for IRMAAuthenticationRequest.
-type IRMAAuthenticationRequest struct {
-	// Internal ID of the customer for which is being logged in
-	CustomerID int `json:"customerID"`
-}
-
 // InboxEntry defines model for InboxEntry.
 type InboxEntry struct {
 	// Date/time of the entry.
@@ -297,9 +291,6 @@ type TransferRequest struct {
 // SetCustomerJSONBody defines parameters for SetCustomer.
 type SetCustomerJSONBody Customer
 
-// AuthenticateWithIRMAJSONBody defines parameters for AuthenticateWithIRMA.
-type AuthenticateWithIRMAJSONBody IRMAAuthenticationRequest
-
 // AuthenticateWithPasswordJSONBody defines parameters for AuthenticateWithPassword.
 type AuthenticateWithPasswordJSONBody PasswordAuthenticateRequest
 
@@ -356,9 +347,6 @@ type UpdateTransferNegotiationStatusJSONBody TransferNegotiationStatus
 
 // SetCustomerJSONRequestBody defines body for SetCustomer for application/json ContentType.
 type SetCustomerJSONRequestBody SetCustomerJSONBody
-
-// AuthenticateWithIRMAJSONRequestBody defines body for AuthenticateWithIRMA for application/json ContentType.
-type AuthenticateWithIRMAJSONRequestBody AuthenticateWithIRMAJSONBody
 
 // AuthenticateWithPasswordJSONRequestBody defines body for AuthenticateWithPassword for application/json ContentType.
 type AuthenticateWithPasswordJSONRequestBody AuthenticateWithPasswordJSONBody

--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func registerEHR(server *echo.Echo, config Config, customerRepository customers.
 	server.Use(auth.JWTHandler)
 	server.Use(sql.Transactional(sqlDB))
 
-	// for requests that require Nuts AccesToken
+	// for requests that require Nuts AccessToken
 	server.Use(authMiddleware(authService))
 
 	api.RegisterHandlersWithBaseURL(server, apiWrapper, "/web")

--- a/nuts/client/auth.go
+++ b/nuts/client/auth.go
@@ -13,6 +13,9 @@ import (
 type Auth interface {
 	CreateIrmaSession(customer domain.Customer) ([]byte, error)
 	GetIrmaSessionResult(sessionToken string) ([]byte, error)
+
+	CreateDummySession(customer domain.Customer) ([]byte, error)
+	GetDummySessionResult(sessionToken string) ([]byte, error)
 }
 
 func (c HTTPClient) CreateIrmaSession(customer domain.Customer) ([]byte, error) {
@@ -57,6 +60,32 @@ func (c HTTPClient) CreateIrmaSession(customer domain.Customer) ([]byte, error) 
 func (c HTTPClient) GetIrmaSessionResult(sessionToken string) ([]byte, error) {
 	// todo set user session
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := c.auth().GetSignSessionStatus(ctx, sessionToken)
+	if err != nil {
+		return nil, err
+	}
+	return testAndReadResponse(http.StatusOK, resp)
+}
+
+func (c HTTPClient) CreateDummySession(customer domain.Customer) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	body := nutsAuthClient.CreateSignSessionJSONRequestBody{
+		Means:   "dummy",
+		Payload: "Ik verklaar te handelen namens " + customer.Name,
+	}
+
+	resp, err := c.auth().CreateSignSession(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return testAndReadResponse(http.StatusCreated, resp)
+}
+
+func (c HTTPClient) GetDummySessionResult(sessionToken string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	resp, err := c.auth().GetSignSessionStatus(ctx, sessionToken)

--- a/nuts/client/auth.go
+++ b/nuts/client/auth.go
@@ -12,13 +12,45 @@ import (
 
 type Auth interface {
 	CreateIrmaSession(customer domain.Customer) ([]byte, error)
-	GetIrmaSessionResult(sessionToken string) ([]byte, error)
+	GetIrmaSessionResult(sessionToken string) (*nutsAuthClient.SignSessionStatusResponse, error)
 
 	CreateDummySession(customer domain.Customer) ([]byte, error)
-	GetDummySessionResult(sessionToken string) ([]byte, error)
+	GetDummySessionResult(sessionToken string) (*nutsAuthClient.SignSessionStatusResponse, error)
+}
+
+func (c HTTPClient) getSessionResult(sessionToken string) (*nutsAuthClient.SignSessionStatusResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := c.auth().GetSignSessionStatus(ctx, sessionToken)
+	if err != nil {
+		return nil, err
+	}
+	respData, err := testAndReadResponse(http.StatusOK, resp)
+	if err != nil {
+		return nil, err
+	}
+	sessionResponse := &nutsAuthClient.SignSessionStatusResponse{}
+	json.Unmarshal(respData, sessionResponse)
+	return sessionResponse, nil
 }
 
 func (c HTTPClient) CreateIrmaSession(customer domain.Customer) ([]byte, error) {
+	return c.createSession(customer, nutsAuthClient.SignSessionRequestMeansIrma)
+}
+
+func (c HTTPClient) GetIrmaSessionResult(sessionToken string) (*nutsAuthClient.SignSessionStatusResponse, error) {
+	return c.getSessionResult(sessionToken)
+}
+
+func (c HTTPClient) CreateDummySession(customer domain.Customer) ([]byte, error) {
+	return c.createSession(customer, nutsAuthClient.SignSessionRequestMeansDummy)
+}
+
+func (c HTTPClient) GetDummySessionResult(sessionToken string) (*nutsAuthClient.SignSessionStatusResponse, error) {
+	return c.getSessionResult(sessionToken)
+}
+
+func (c HTTPClient) createSession(customer domain.Customer, means nutsAuthClient.SignSessionRequestMeans) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -46,7 +78,7 @@ func (c HTTPClient) CreateIrmaSession(customer domain.Customer) ([]byte, error) 
 	}
 
 	body := nutsAuthClient.CreateSignSessionJSONRequestBody{
-		Means:   "irma",
+		Means:   means,
 		Payload: contract.Message,
 	}
 
@@ -55,44 +87,6 @@ func (c HTTPClient) CreateIrmaSession(customer domain.Customer) ([]byte, error) 
 		return nil, err
 	}
 	return testAndReadResponse(http.StatusCreated, resp)
-}
-
-func (c HTTPClient) GetIrmaSessionResult(sessionToken string) ([]byte, error) {
-	// todo set user session
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	resp, err := c.auth().GetSignSessionStatus(ctx, sessionToken)
-	if err != nil {
-		return nil, err
-	}
-	return testAndReadResponse(http.StatusOK, resp)
-}
-
-func (c HTTPClient) CreateDummySession(customer domain.Customer) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	body := nutsAuthClient.CreateSignSessionJSONRequestBody{
-		Means:   "dummy",
-		Payload: "Ik verklaar te handelen namens " + customer.Name,
-	}
-
-	resp, err := c.auth().CreateSignSession(ctx, body)
-	if err != nil {
-		return nil, err
-	}
-	return testAndReadResponse(http.StatusCreated, resp)
-}
-
-func (c HTTPClient) GetDummySessionResult(sessionToken string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	resp, err := c.auth().GetSignSessionStatus(ctx, sessionToken)
-	if err != nil {
-		return nil, err
-	}
-	return testAndReadResponse(http.StatusOK, resp)
 }
 
 func (c HTTPClient) auth() nutsAuthClient.ClientInterface {

--- a/web/src/Login.vue
+++ b/web/src/Login.vue
@@ -39,6 +39,7 @@ import irma from "@privacybydesign/irma-frontend";
 import irmaLogo from './img/irma-logo.png';
 
 export default {
+  props: ['redirectPath'],
   data() {
     return {
       loginError: "",
@@ -66,9 +67,6 @@ export default {
     }
   },
   methods: {
-    redirectAfterLogin() {
-      this.$router.push("/ehr/")
-    },
     fetchData() {
       this.$api.listCustomers()
           .then(data => this.customers = data)
@@ -84,24 +82,14 @@ export default {
     },
     loginWithPassword() {
       if (this.selectedCustomer) {
-        this.$router.push({name: 'auth.passwd', params: {customer: JSON.stringify(this.selectedCustomer)}})
+        this.$router.push({name: 'auth.passwd', params: {customer: JSON.stringify(this.selectedCustomer)}, query: {redirect: this.redirectPath}})
       }
     },
     loginWithIRMA() {
       if (this.selectedCustomer) {
-        this.$router.push({name: 'auth.irma', params: {customer: JSON.stringify(this.selectedCustomer)}})
+        this.$router.push({name: 'auth.irma', params: {customer: JSON.stringify(this.selectedCustomer)}, query: {redirect: this.redirectPath}})
       }
     }
   },
-  mounted() {
-    // Disabled since it causes infinite loops since the $api service is redirecting to this page when a 401 is returned.
-    // Can be enabled when switching back to a JWT. Only perform when it is present.
-    // Check if session still valid, if so just redirect to application
-    // this.$api.get('web/private')
-    //     .then(() => this.redirectAfterLogin())
-    //     .catch(() => {
-    //       // session is invalid, need to authenticate
-    //     })
-  }
 }
 </script>

--- a/web/src/components/auth/IRMAAuthentication.vue
+++ b/web/src/components/auth/IRMAAuthentication.vue
@@ -6,7 +6,6 @@ import irma from "@privacybydesign/irma-frontend";
 
 export default {
   props: {
-    customer: Object,
     headerMessage: {
       type: String,
       default: "Authenticate",

--- a/web/src/components/auth/IRMALogin.vue
+++ b/web/src/components/auth/IRMALogin.vue
@@ -42,18 +42,20 @@ export default {
 
           // Define your disclosure request:
           start: {
+            url: o => `${o.url}/session`,
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
+              // Send the session token in the request which contains the current customerID
+              'Authorization': `Bearer ${localStorage.getItem("session")}`
             },
-            body: JSON.stringify({customerID: this.customer.id})
           },
           mapping: {
             sessionPtr: r => r.sessionPtr.clientPtr,
             sessionToken: r => r.sessionID
           },
           result: {
-            url:           (o, {sessionPtr, sessionToken}) => `${o.url}/session/${sessionToken}/result`,
+            url: (o, {sessionPtr, sessionToken}) => `${o.url}/session/${sessionToken}/result`,
             headers: {
               'Authorization': `Bearer ${localStorage.getItem("session")}`
             },

--- a/web/src/components/auth/IRMALogin.vue
+++ b/web/src/components/auth/IRMALogin.vue
@@ -5,6 +5,7 @@
 import irma from "@privacybydesign/irma-frontend";
 
 export default {
+  props: ['redirectPath'],
   data() {
     return {
       customer: null,
@@ -21,7 +22,9 @@ export default {
   },
   methods: {
     redirectAfterLogin() {
-      console.log('logged in, redirecting!')
+      if (this.redirectPath) {
+        return this.$router.push(this.redirectPath)
+      }
       this.$router.push("/ehr/")
     },
     perform() {

--- a/web/src/components/auth/IRMALogin.vue
+++ b/web/src/components/auth/IRMALogin.vue
@@ -1,11 +1,16 @@
 <template>
-  <div></div>
+  <irma-auth
+      v-if="customer"
+      :header-message="'Authenticate for ' + customer.name"
+      @success="successHandler"
+  />
 </template>
 <script>
-import irma from "@privacybydesign/irma-frontend";
+import irmaAuth from './IRMAAuthentication.vue'
 
 export default {
   props: ['redirectPath'],
+  components: {irmaAuth},
   data() {
     return {
       customer: null,
@@ -14,75 +19,20 @@ export default {
   mounted() {
     if ('customer' in this.$route.params) {
       this.customer = JSON.parse(this.$route.params.customer)
-      this.perform()
     } else {
       // Missing required params, redirect to landing page
       this.$router.push("/")
     }
   },
   methods: {
-    redirectAfterLogin() {
+    successHandler(token) {
+      console.log("success!", token)
+      localStorage.setItem("session", token)
       if (this.redirectPath) {
         return this.$router.push(this.redirectPath)
       }
       this.$router.push("/ehr/")
     },
-    perform() {
-      let options = {
-        // Developer options
-        debugging: true,
-
-        // Front-end options
-        language: 'en',
-        translations: {
-          header: "Authenticate for " + this.customer.name
-        },
-
-        // Back-end options
-        session: {
-          // Point to demo-ehr backend which forwards requests
-          url: '/web/auth/irma',
-
-          // Define your disclosure request:
-          start: {
-            url: o => `${o.url}/session`,
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              // Send the session token in the request which contains the current customerID
-              'Authorization': `Bearer ${localStorage.getItem("session")}`
-            },
-          },
-          mapping: {
-            sessionPtr: r => r.sessionPtr.clientPtr,
-            sessionToken: r => r.sessionID
-          },
-          result: {
-            url: (o, {sessionPtr, sessionToken}) => `${o.url}/session/${sessionToken}/result`,
-            headers: {
-              'Authorization': `Bearer ${localStorage.getItem("session")}`
-            },
-            parseResponse: r => r.json()
-          }
-        }
-      };
-      let irmaPopup = irma.newPopup(options);
-      irmaPopup.start()
-          .then(responseData => {
-            localStorage.setItem("session", responseData.token)
-            console.log("IRMA authentication successful")
-            this.redirectAfterLogin()
-          })
-          .catch(error => {
-            if (error === 'Aborted') {
-              console.log('IRMA authentication aborted')
-              this.$router.push("/")
-              return;
-            }
-            console.error("error", error);
-          })
-          .finally(() => irmaPopup = irma.newPopup(options))
-    }
   }
 }
 </script>

--- a/web/src/components/auth/IRMALogin.vue
+++ b/web/src/components/auth/IRMALogin.vue
@@ -5,18 +5,25 @@
 import irma from "@privacybydesign/irma-frontend";
 
 export default {
-  props: {
-    customer: Object,
-    headerMessage: {
-      type: String,
-      default: "Authenticate",
+  data() {
+    return {
+      customer: null,
     }
   },
   mounted() {
-    this.perform()
+    if ('customer' in this.$route.params) {
+      this.customer = JSON.parse(this.$route.params.customer)
+      this.perform()
+    } else {
+      // Missing required params, redirect to landing page
+      this.$router.push("/")
+    }
   },
-  emits: ['success', 'aborted', 'error'],
   methods: {
+    redirectAfterLogin() {
+      console.log('logged in, redirecting!')
+      this.$router.push("/ehr/")
+    },
     perform() {
       let options = {
         // Developer options
@@ -25,30 +32,28 @@ export default {
         // Front-end options
         language: 'en',
         translations: {
-          header: this.headerMessage
+          header: "Authenticate for " + this.customer.name
         },
 
         // Back-end options
         session: {
-          // Set base-url path to demo-ehr endpoint which forwards requests to IRMA server (embedded in the Nuts Node)
+          // Point to demo-ehr backend which forwards requests
           url: '/web/auth/irma',
 
           // Define your disclosure request:
           start: {
-            url: o => `${o.url}/session`,
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              // Send the session token in the request which contains the current customerID
-              'Authorization': `Bearer ${localStorage.getItem("session")}`
             },
+            body: JSON.stringify({customerID: this.customer.id})
           },
           mapping: {
             sessionPtr: r => r.sessionPtr.clientPtr,
             sessionToken: r => r.sessionID
           },
           result: {
-            url: (o, {sessionPtr, sessionToken}) => `${o.url}/session/${sessionToken}/result`,
+            url:           (o, {sessionPtr, sessionToken}) => `${o.url}/session/${sessionToken}/result`,
             headers: {
               'Authorization': `Bearer ${localStorage.getItem("session")}`
             },
@@ -59,17 +64,17 @@ export default {
       let irmaPopup = irma.newPopup(options);
       irmaPopup.start()
           .then(responseData => {
+            localStorage.setItem("session", responseData.token)
             console.log("IRMA authentication successful")
-            this.$emit('success', responseData.token)
+            this.redirectAfterLogin()
           })
           .catch(error => {
             if (error === 'Aborted') {
               console.log('IRMA authentication aborted')
-              this.$emit('aborted', error)
+              this.$router.push("/")
               return;
             }
             console.error("error", error);
-            this.$emit('error', error)
           })
           .finally(() => irmaPopup = irma.newPopup(options))
     }

--- a/web/src/components/auth/PasswordAuthentication.vue
+++ b/web/src/components/auth/PasswordAuthentication.vue
@@ -28,6 +28,7 @@
 
 <script>
 export default {
+  props: ['redirectPath'],
   data() {
     return {
       loginError: "",
@@ -48,8 +49,10 @@ export default {
   },
   methods: {
     redirectAfterLogin() {
-      console.log('logged in, redirecting!')
-      this.$router.push({name: "ehr.home"})
+      if (this.redirectPath) {
+        return this.$router.push(this.redirectPath)
+      }
+      this.$router.push("/ehr/")
     },
     login() {
       this.$api.authenticateWithPassword({body: this.credentials})

--- a/web/src/components/auth/SessionElevation.vue
+++ b/web/src/components/auth/SessionElevation.vue
@@ -20,7 +20,7 @@
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen></iframe>
 
-  <irma-login v-if="means === 'irma'" @success="onIRMASuccess"></irma-login>
+  <irma-login v-if="means === 'irma'" @success="onElevationSuccess"></irma-login>
 </template>
 
 <script>
@@ -37,18 +37,29 @@ export default {
     }
   },
   methods: {
-    elevateWithIRMA() {
-      this.means = "irma"
-    },
-    onIRMASuccess(token) {
-      console.log("irma success!", token)
+    onElevationSuccess(token) {
+      console.log("elevation success!", token)
       localStorage.setItem("session", token)
       this.$router.push(this.redirectPath)
+    },
+    elevateWithIRMA() {
+      this.means = "irma"
     },
     elevateWithBONO() {
       this.means = "bono"
     },
     elevateWithDummy() {
+      console.log("elevate with Dummy")
+      this.$api.authenticateWithDummy()
+          .then((res) => {
+            console.log(res)
+            return this.$api.getDummyAuthenticationResult({sessionToken: res.sessionID})
+                .then((responseData) => {
+                  this.onElevationSuccess(responseData.token)
+                })
+                .catch(err => console.log(err))
+          })
+          .catch(err => console.log(err))
 
     }
   }

--- a/web/src/components/auth/SessionElevation.vue
+++ b/web/src/components/auth/SessionElevation.vue
@@ -1,26 +1,35 @@
 <template>
 
-  <div v-if="!means">
-    Choose a means to elevate your session:
-    <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithIRMA">
-      <div>IRMA</div>
-      <img class="block my-3" v-bind:src="irmaLogo">
-    </button>
-    <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithBONO">
-      <div>BONO</div>
-    </button>
-    <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithDummy">
-      Dummy (for easy testing)
-    </button>
+  <div class="flex justify-center">
+
+    <div v-if="!means" class="mt-12 border rounded-md max-w-7xl p-8 flex flex-col">
+      <p>The page you want to access requires a higher lever of authentication.</p>
+
+      <p>Choose a means to elevate your session:</p>
+      <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithIRMA">
+        <div>IRMA</div>
+        <img class="block my-3" v-bind:src="irmaLogo">
+      </button>
+      <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithBONO">
+        <div>BONO</div>
+      </button>
+      <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithDummy">
+        Dummy (for easy testing)
+      </button>
+    </div>
+    <button v-else @click="means = ''">back</button>
+
+
+    <iframe v-if="means === 'bono'" width="560" height="315" src="https://www.youtube-nocookie.com/embed/19KstSgU-c0"
+            title="YouTube video player" frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen></iframe>
+
+    <irma-login v-if="means === 'irma'"
+                @success="onElevationSuccess"
+                @aborted="means = ''"
+    ></irma-login>
   </div>
-
-
-  <iframe v-if="means === 'bono'" width="560" height="315" src="https://www.youtube-nocookie.com/embed/19KstSgU-c0"
-          title="YouTube video player" frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen></iframe>
-
-  <irma-login v-if="means === 'irma'" @success="onElevationSuccess"></irma-login>
 </template>
 
 <script>

--- a/web/src/components/auth/SessionElevation.vue
+++ b/web/src/components/auth/SessionElevation.vue
@@ -1,0 +1,56 @@
+<template>
+
+  <div v-if="!means">
+    Choose a means to elevate your session:
+    <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithIRMA">
+      <div>IRMA</div>
+      <img class="block my-3" v-bind:src="irmaLogo">
+    </button>
+    <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithBONO">
+      <div>BONO</div>
+    </button>
+    <button class="w-full btn btn-submit grid justify-items-center" @click="elevateWithDummy">
+      Dummy (for easy testing)
+    </button>
+  </div>
+
+
+  <iframe v-if="means === 'bono'" width="560" height="315" src="https://www.youtube-nocookie.com/embed/19KstSgU-c0"
+          title="YouTube video player" frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen></iframe>
+
+  <irma-login v-if="means === 'irma'" @success="onIRMASuccess"></irma-login>
+</template>
+
+<script>
+import IrmaLogin from './IRMAAuthentication.vue'
+import irmaLogo from '../../img/irma-logo.png'
+
+export default {
+  props: ['redirectPath'],
+  components: {IrmaLogin},
+  data() {
+    return {
+      means: null,
+      irmaLogo: irmaLogo
+    }
+  },
+  methods: {
+    elevateWithIRMA() {
+      this.means = "irma"
+    },
+    onIRMASuccess(token) {
+      console.log("irma success!", token)
+      localStorage.setItem("session", token)
+      this.$router.push(this.redirectPath)
+    },
+    elevateWithBONO() {
+      this.means = "bono"
+    },
+    elevateWithDummy() {
+
+    }
+  }
+}
+</script>

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -29,7 +29,8 @@ const routes = [
   {
     name: 'login',
     path: '/login',
-    component: Login
+    component: Login,
+    props: route => ({redirectPath: route.query.redirect})
   },
   {
     name: 'logout',
@@ -40,11 +41,13 @@ const routes = [
     name: 'auth.passwd',
     path: '/auth/passwd/',
     component: PasswordAuthentication,
+    props: route => ({redirectPath: route.query.redirect})
   },
   {
     name: 'auth.irma',
     path: '/auth/irma/',
     component: IRMALogin,
+    props: route => ({redirectPath: route.query.redirect})
   },
   {
     path: '/ehr',
@@ -142,8 +145,8 @@ router.beforeEach((to, from, next) => {
   // Check before rendering the target route that we're authenticated, if it's required by the particular route.
   if (to.meta.requiresAuth === true) {
     if (!localStorage.getItem("session")) {
-      console.log("no cookie found, redirect to login")
-      return '/login'
+      console.log("no active session found, redirect to login")
+      return next({name: 'login', props: true, query: {redirect: to.path }})
     }
   }
   if (to.meta.requiresElevation === true) {
@@ -152,7 +155,7 @@ router.beforeEach((to, from, next) => {
     let token = JSON.parse(rawToken)
     if (!token["elv"]) {
       console.log("route requires elevation, redirect to elevate")
-      next({name: 'ehr.elevate', props: true, query: {redirect: to.path }})
+      return next({name: 'ehr.elevate', props: true, query: {redirect: to.path }})
     }
   }
   next()

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -5,7 +5,7 @@ import App from './App.vue'
 import EHRApp from './ehr/EHRApp.vue'
 import Login from './Login.vue'
 import PasswordAuthentication from './components/auth/PasswordAuthentication.vue'
-import IRMAAuthentication from './components/auth/IRMAAuthentication.vue'
+import IRMALogin from './components/auth/IRMALogin.vue'
 import Logout from './Logout.vue'
 import NotFound from './NotFound.vue'
 import Api from './plugins/api'
@@ -44,7 +44,7 @@ const routes = [
   {
     name: 'auth.irma',
     path: '/auth/irma/',
-    component: IRMAAuthentication,
+    component: IRMALogin,
   },
   {
     path: '/ehr',

--- a/web/src/plugins/api-impl.js
+++ b/web/src/plugins/api-impl.js
@@ -72,10 +72,37 @@ function createApi(options) {
 
         });
     },
+    authenticateWithDummy(parameters) {
+      const params = typeof parameters === 'undefined' ? {} : parameters;
+      let headers = {
+
+      };
+      handleSecurity([{"bearerAuth":[]}]
+          , headers, params, 'authenticateWithDummy');
+      return fetch(endpoint + basePath + '/auth/dummy'
+        , {
+          method: 'POST',
+          headers,
+          mode,
+        });
+    },
+    getDummyAuthenticationResult(parameters) {
+      const params = typeof parameters === 'undefined' ? {} : parameters;
+      let headers = {
+
+      };
+      handleSecurity([{"bearerAuth":[]}]
+          , headers, params, 'getDummyAuthenticationResult');
+      return fetch(endpoint + basePath + '/auth/dummy/session/' + params['sessionToken'] + '/result'
+        , {
+          method: 'GET',
+          headers,
+          mode,
+        });
+    },
     authenticateWithIRMA(parameters) {
       const params = typeof parameters === 'undefined' ? {} : parameters;
       let headers = {
-        'content-type': 'application/json',
 
       };
       handleSecurity([{"bearerAuth":[]}]
@@ -85,8 +112,6 @@ function createApi(options) {
           method: 'POST',
           headers,
           mode,
-          body: JSON.stringify(params['body']),
-
         });
     },
     getIRMAAuthenticationResult(parameters) {


### PR DESCRIPTION
Allows for elevation when the user is not yet elevated, e.g. logged in with username and password.

There is some duplicate code when creating a signing session and getting the results for the Dummy and IRMA means. I think it helps for clearity. We can choose to unduplicate if we think dry is better than being explicit.

TODO:
* [x] Combine IRMALogin.vue with IRMAAuthentication.vue
* [x] Add the Dummy means