### PR TITLE
Fix several issues when updating a transfer

### DIFF
--- a/api/transfer.go
+++ b/api/transfer.go
@@ -50,10 +50,12 @@ func (w Wrapper) GetTransfer(ctx echo.Context, transferID string) error {
 	if err != nil {
 		return err
 	}
+
 	transfer, err := w.TransferSenderService.GetTransferByID(ctx.Request().Context(), cid, transferID)
 	if err != nil {
 		return err
 	}
+
 	return ctx.JSON(http.StatusOK, transfer)
 }
 
@@ -85,11 +87,18 @@ func (w Wrapper) UpdateTransfer(ctx echo.Context, transferID string) error {
 	if err != nil {
 		return err
 	}
-	transfer, err := w.TransferSenderRepo.Update(ctx.Request().Context(), cid, transferID, func(t *domain.Transfer) (*domain.Transfer, error) {
+
+	_, err = w.TransferSenderRepo.Update(ctx.Request().Context(), cid, transferID, func(t *domain.Transfer) (*domain.Transfer, error) {
 		//t.Description = updateRequest.Description
 		t.TransferDate = updateRequest.TransferDate
 		return t, nil
 	})
+
+	transfer, err := w.TransferSenderService.GetTransferByID(ctx.Request().Context(), cid, transferID)
+	if err != nil {
+		return err
+	}
+
 	return ctx.JSON(http.StatusOK, transfer)
 }
 

--- a/web/src/components/StatusBar.vue
+++ b/web/src/components/StatusBar.vue
@@ -2,6 +2,7 @@
   <div class="fixed p-4 bottom-0 flex" v-if="show">
     <div class="rounded-md bg-green-300 p-4 flex justify-between">
       {{ statusMessage }}
+
       <div class="cursor-pointer text-white">
         <svg @click="show = false" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24"
              stroke="currentColor">

--- a/web/src/components/StatusReporter.vue
+++ b/web/src/components/StatusReporter.vue
@@ -1,7 +1,7 @@
 <template>
-  <p class="p-3 bg-red-100 rounded-md mb-4"
+  <div class="px-6 py-4 bg-red-100 rounded-md mb-4 fixed top-10 right-10 shadow-md"
      :class="{ 'bg-red-100': type === 'error', 'bg-blue-100': type === 'info' }"
-     v-if="show">{{ message }}</p>
+     v-if="show">{{ message }}</div>
 </template>
 
 <script>

--- a/web/src/ehr/transfer/EditTransfer.vue
+++ b/web/src/ehr/transfer/EditTransfer.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
-    <transfer-form v-if="transfer" :transfer="transfer"
-                   @input="(updatedTransfer) => {this.transfer = updatedTransfer}"/>
+    <transfer-form
+        v-if="transfer"
+        :transfer="transfer"
+        mode="edit"
+        @input="(updatedTransfer) => {this.transfer = updatedTransfer}"/>
 
     <div class="bg-white p-5 shadow-sm rounded-lg mt-6">
       <table class="min-w-full divide-y divide-gray-200" v-if="transfer">

--- a/web/src/ehr/transfer/TransferForm.vue
+++ b/web/src/ehr/transfer/TransferForm.vue
@@ -12,6 +12,7 @@
       <h2>Problems</h2>
 
       <button
+          v-if="mode === 'new'"
           @click="transfer.carePlan.patientProblems.push({problem: {name: ''}, interventions: [{comment: ''}]})"
           class="float-right inline-flex items-center bg-nuts w-10 h-10 rounded-lg justify-center shadow-md"
       >
@@ -26,7 +27,14 @@
       <label>Problem</label>
 
       <div>
-        <textarea placeholder="The problem.." v-model="patientProblem.problem.name" class="min-w-full border" required></textarea>
+        <textarea
+            v-if="mode === 'new'"
+            placeholder="The problem.."
+            v-model="patientProblem.problem.name"
+            class="min-w-full border"
+            required
+        ></textarea>
+        <p v-else>{{patientProblem.problem.name}}</p>
 
         <div v-for="(intervention, i) in patientProblem.interventions" class="mt-3">
           <label>
@@ -34,8 +42,13 @@
             <span v-if="patientProblem.interventions.length > 1">{{ i + 1 }}</span>
           </label>
 
-          <textarea placeholder="The intervention.." @input="e => addOrRemoveIntervention(e, patientProblem)" v-model="intervention.comment"
-                    class="min-w-full border"></textarea>
+          <textarea
+              v-if="mode === 'new'"
+              placeholder="The intervention.."
+              @input="e => addOrRemoveIntervention(e, patientProblem)"
+              v-model="intervention.comment"
+              class="min-w-full border"></textarea>
+          <p v-else>{{intervention.comment}}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
In the edit transfer screen the patient problem fields are now uneditable paragraphs instead of textareas as updating them is not implemented yet. So for now only basic information can be updated but at least that works..