### PR TITLE
Lazy load the customers DB, eases orchestration with registry-admin

### DIFF
--- a/domain/customers/repository.go
+++ b/domain/customers/repository.go
@@ -4,11 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/labstack/gommon/log"
+	"github.com/nuts-foundation/nuts-demo-ehr/domain/types"
 	"os"
 	"sort"
-	"sync"
-
-	"github.com/nuts-foundation/nuts-demo-ehr/domain/types"
 )
 
 type Repository interface {
@@ -19,9 +17,6 @@ type Repository interface {
 
 type jsonFileRepo struct {
 	filepath string
-	mutex    sync.Mutex
-	// records is a cache
-	records map[string]types.Customer
 }
 
 func NewJsonFileRepository(filepath string) *jsonFileRepo {
@@ -33,23 +28,18 @@ func NewJsonFileRepository(filepath string) *jsonFileRepo {
 		// In Docker environments, it might not be there yet if demo-ehr starts first.
 	}
 
-	repo := jsonFileRepo{
+	return &jsonFileRepo{
 		filepath: filepath,
-		mutex:    sync.Mutex{},
-		records:  make(map[string]types.Customer, 0),
 	}
-
-	return &repo
 }
 
 func (db *jsonFileRepo) FindByID(id int) (*types.Customer, error) {
-	if len(db.records) == 0 {
-		if err := db.readAll(); err != nil {
-			return nil, err
-		}
+	records, err := db.read()
+	if err != nil {
+		return nil, err
 	}
 
-	for _, r := range db.records {
+	for _, r := range records {
 		if r.Id == id {
 			// Hazardous to return a pointer, but this is a demo.
 			return &r, nil
@@ -61,13 +51,12 @@ func (db *jsonFileRepo) FindByID(id int) (*types.Customer, error) {
 }
 
 func (db *jsonFileRepo) FindByDID(did string) (*types.Customer, error) {
-	if len(db.records) == 0 {
-		if err := db.readAll(); err != nil {
-			return nil, err
-		}
+	records, err := db.read()
+	if err != nil {
+		return nil, err
 	}
 
-	for _, r := range db.records {
+	for _, r := range records {
 		if r.Did != nil && *r.Did == did {
 			// Hazardous to return a pointer, but this is a demo.
 			return &r, nil
@@ -78,43 +67,39 @@ func (db *jsonFileRepo) FindByDID(did string) (*types.Customer, error) {
 	return nil, nil
 }
 
-func (db *jsonFileRepo) readAll() error {
-	bytes, err := os.ReadFile(db.filepath)
-	if err != nil {
-		return fmt.Errorf("unable to read db from file: %w", err)
-	}
-
-	if len(bytes) == 0 {
-		return nil
-	}
-
-	v := map[string]types.Customer{}
-	if err = json.Unmarshal(bytes, &v); err != nil {
-		return fmt.Errorf("unable to unmarshall db from file: %w", err)
-	}
-
-	db.records = v
-
-	return nil
-}
-
 func (db *jsonFileRepo) All() ([]types.Customer, error) {
-	db.mutex.Lock()
-	defer db.mutex.Unlock()
-
-	if err := db.readAll(); err != nil {
+	records, err := db.read()
+	if err != nil {
 		return nil, err
 	}
 
-	v := make([]types.Customer, len(db.records))
+	v := make([]types.Customer, len(records))
 
 	idx := 0
-	for _, value := range db.records {
+	for _, value := range records {
 		v[idx] = value
 		idx = idx + 1
 	}
 	sort.SliceStable(v, func(i, j int) bool {
 		return v[i].Name < v[j].Name
 	})
+	return v, nil
+}
+
+func (db *jsonFileRepo) read() (map[string]types.Customer, error) {
+	bytes, err := os.ReadFile(db.filepath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read db from file: %w", err)
+	}
+
+	if len(bytes) == 0 {
+		return nil, nil
+	}
+
+	v := map[string]types.Customer{}
+	if err = json.Unmarshal(bytes, &v); err != nil {
+		return nil, fmt.Errorf("unable to unmarshall db from file: %w", err)
+	}
+
 	return v, nil
 }


### PR DESCRIPTION
When used with registry-admin in Docker, `customers.json` is mounted in both containers. But it is created by registry-admin, so if demo-ehr starts first it will crash if the file does not exist beforehand. This change allows demo-ehr to start nonetheless (and it will be read when present).