### PR TITLE
Add .dockerignore to make local builds faster, 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.idea


### PR DESCRIPTION
By not transferring node_modules to Docker VM