### PR TITLE
VCR: Copy VC search query type from Nuts node

### DIFF
--- a/nuts/client/vcr.go
+++ b/nuts/client/vcr.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/vc"
-	v2 "github.com/nuts-foundation/nuts-node/vcr/api/v2"
 	"github.com/nuts-foundation/nuts-node/vcr/credential"
 	"github.com/nuts-foundation/nuts-node/vcr/holder"
 	"github.com/sirupsen/logrus"
@@ -17,8 +16,8 @@ import (
 
 type VCRClient interface {
 	CreateVC(ctx context.Context, typeName, issuer string, credentialSubject map[string]interface{}, expirationDate *time.Time, publishPublic bool) error
-	FindCredentials(ctx context.Context, credential v2.SearchVCQuery, untrusted bool) ([]vc.VerifiableCredential, error)
-	FindCredentialIDs(ctx context.Context, credential v2.SearchVCQuery, untrusted bool) ([]string, error)
+	FindCredentials(ctx context.Context, credential vcr.SearchVCQuery, untrusted bool) ([]vc.VerifiableCredential, error)
+	FindCredentialIDs(ctx context.Context, credential vcr.SearchVCQuery, untrusted bool) ([]string, error)
 	RevokeCredential(ctx context.Context, credentialID string) error
 	ResolveCredential(ctx context.Context, credentialID string) (*vc.VerifiableCredential, error)
 }
@@ -57,11 +56,11 @@ func (c HTTPClient) CreateVC(ctx context.Context, typeName, issuer string, crede
 	return nil
 }
 
-func (c HTTPClient) FindCredentials(ctx context.Context, credential v2.SearchVCQuery, untrusted bool) ([]vc.VerifiableCredential, error) {
+func (c HTTPClient) FindCredentials(ctx context.Context, credential vcr.SearchVCQuery, untrusted bool) ([]vc.VerifiableCredential, error) {
 	return c.search(ctx, credential, untrusted)
 }
 
-func (c HTTPClient) FindCredentialIDs(ctx context.Context, credential v2.SearchVCQuery, untrusted bool) ([]string, error) {
+func (c HTTPClient) FindCredentialIDs(ctx context.Context, credential vcr.SearchVCQuery, untrusted bool) ([]string, error) {
 	credentials, err := c.search(ctx, credential, untrusted)
 	if err != nil {
 		return nil, err
@@ -102,15 +101,15 @@ func (c HTTPClient) ResolveCredential(ctx context.Context, credentialID string) 
 	return &result, nil
 }
 
-func GetNutsCredentialTemplate(credentialType ssi.URI) v2.SearchVCQuery {
-	return v2.SearchVCQuery{
+func GetNutsCredentialTemplate(credentialType ssi.URI) vcr.SearchVCQuery {
+	return vcr.SearchVCQuery{
 		Context: []ssi.URI{holder.VerifiableCredentialLDContextV1, credential.NutsV1ContextURI},
 		Type:    []ssi.URI{vc.VerifiableCredentialTypeV1URI(), credentialType},
 	}
 }
 
-func (c HTTPClient) search(ctx context.Context, credential v2.SearchVCQuery, untrusted bool) ([]vc.VerifiableCredential, error) {
-	response, err := c.vcr().SearchVCs(ctx, vcr.SearchVCsJSONRequestBody{Query: credential, SearchOptions: &v2.SearchOptions{
+func (c HTTPClient) search(ctx context.Context, credential vcr.SearchVCQuery, untrusted bool) ([]vc.VerifiableCredential, error) {
+	response, err := c.vcr().SearchVCs(ctx, vcr.SearchVCsJSONRequestBody{Query: credential, SearchOptions: &vcr.SearchOptions{
 		AllowUntrustedIssuer: &untrusted,
 	}})
 	if err != nil {

--- a/nuts/client/vcr/types.go
+++ b/nuts/client/vcr/types.go
@@ -1,15 +1,31 @@
 package vcr
 
 import (
+	ssi "github.com/nuts-foundation/go-did"
 	"github.com/nuts-foundation/go-did/did"
 	"github.com/nuts-foundation/go-did/vc"
-	v2 "github.com/nuts-foundation/nuts-node/vcr/api/v2"
 )
-
-// SearchVCRequest is the request body for searching VCs
-type SearchVCRequest v2.SearchVCRequest
 
 type VerifiableCredential = vc.VerifiableCredential
 type VerifiablePresentation = vc.VerifiablePresentation
 type DID = did.DID
 type CredentialSubject = interface{}
+
+// SearchVCRequest is the request body for searching VCs
+type SearchVCRequest struct {
+	// A partial VerifiableCredential in JSON-LD format. Each field will be used to match credentials against. All fields MUST be present.
+	Query         SearchVCQuery  `json:"query"`
+	SearchOptions *SearchOptions `json:"searchOptions,omitempty"`
+}
+
+// SearchVCQuery defines a helper struct to search for VerifiableCredentials.
+type SearchVCQuery struct {
+	// Context defines the json-ld context to dereference the URIs
+	Context []ssi.URI `json:"@context"`
+	// Type holds multiple types for a credential. A credential must always have the 'VerifiableCredential' type.
+	Type []ssi.URI `json:"type,omitempty"`
+	// Issuer refers to the party that issued the credential
+	Issuer *ssi.URI `json:"issuer,omitempty"`
+	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
+	CredentialSubject []interface{} `json:"credentialSubject,omitempty"`
+}

--- a/nuts/client/vcr/types.go
+++ b/nuts/client/vcr/types.go
@@ -27,5 +27,5 @@ type SearchVCQuery struct {
 	// Issuer refers to the party that issued the credential
 	Issuer *ssi.URI `json:"issuer,omitempty"`
 	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
-	CredentialSubject []interface{} `json:"credentialSubject,omitempty"`
+	CredentialSubject interface{} `json:"credentialSubject,omitempty"`
 }

--- a/nuts/registry/verifiable_credential.go
+++ b/nuts/registry/verifiable_credential.go
@@ -59,7 +59,7 @@ func (registry *httpVerifiableCredentialRegistry) CreateAuthorizationCredential(
 func (registry *httpVerifiableCredentialRegistry) FindAuthorizationCredentials(ctx context.Context, params *VCRSearchParams) ([]vc.VerifiableCredential, error) {
 	query := nutsClient.GetNutsCredentialTemplate(*credential.NutsAuthorizationCredentialTypeURI)
 	credentialSubject := make(map[string]interface{}, 0)
-	query.CredentialSubject = []interface{}{credentialSubject}
+	query.CredentialSubject = credentialSubject
 
 	// may be extended by issuanceDate for even faster results.
 	credentialSubject["purposeOfUse"] = params.PurposeOfUse
@@ -84,13 +84,11 @@ func (registry *httpVerifiableCredentialRegistry) FindAuthorizationCredentials(c
 func (registry *httpVerifiableCredentialRegistry) RevokeAuthorizationCredential(ctx context.Context, purposeOfUse, subjectID, resourcePath string) error {
 	// may be extended by issuanceDate for even faster results.
 	query := nutsClient.GetNutsCredentialTemplate(*credential.NutsAuthorizationCredentialTypeURI)
-	query.CredentialSubject = []interface{}{
-		map[string]interface{}{
-			"id":           subjectID,
-			"purposeOfUse": purposeOfUse,
-			"resources": map[string]interface{}{
-				"path": resourcePath,
-			},
+	query.CredentialSubject = map[string]interface{}{
+		"id":           subjectID,
+		"purposeOfUse": purposeOfUse,
+		"resources": map[string]interface{}{
+			"path": resourcePath,
 		},
 	}
 	credentialIDs, err := registry.nutsClient.FindCredentialIDs(ctx, query, false)


### PR DESCRIPTION
Required since https://github.com/nuts-foundation/nuts-node/pull/1967 will remove the type from Nuts-node.

Would be a typical type for a client SDK, but there is none, so for now copy is the best approach.