### PR TITLE
add Nuts API security audience setting

### DIFF
--- a/config.go
+++ b/config.go
@@ -80,7 +80,9 @@ type Config struct {
 
 	// NutsNodeKeyPath sets the path for the private key file used to sign JWTs and enable
 	// access to a protected nuts node endpoint. This value is ignored when set empty.
-	NutsNodeKeyPath string
+	NutsNodeKeyPath string `koanf:"nutsnodekeypath"`
+	// NutsNodeAPIAudience sets the 'aud' in the token generation, must match with Nuts node settings.
+	NutsNodeAPIAudience string `koanf:"nutsnodeapiaudience"`
 }
 
 type FHIR struct {

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 			logrus.Fatalf("Failed to open nuts-node key: %v", err)
 		}
 
-		authorizer = &nutsClient.Authorizer{Key: key}
+		authorizer = &nutsClient.Authorizer{Key: key, Audience: config.NutsNodeAPIAudience}
 	}
 
 	// init node API nutsClient

--- a/nuts/client/authorizer.go
+++ b/nuts/client/authorizer.go
@@ -18,7 +18,8 @@ type RequestEditorFn func(ctx context.Context, req *http.Request) error
 
 // Authorizer authorizes requests to nuts-node endpoints using the given private key
 type Authorizer struct {
-	Key keyring.Key
+	Key      keyring.Key
+	Audience string
 }
 
 // RequestEditorFn returns a RequestEditorFn suitable for use in WithRequestEditorFn
@@ -34,7 +35,7 @@ func (a *Authorizer) RequestEditorFn() RequestEditorFn {
 		token, err := jwt.NewBuilder().
 			Issuer("nuts-demo-ehr").
 			Subject("nuts-demo-ehr").
-			Audience([]string{req.URL.Host}).
+			Audience([]string{a.Audience}).
 			IssuedAt(issuedAt).
 			NotBefore(notBefore).
 			Expiration(expires).


### PR DESCRIPTION
Needed to set correct `aud` otherwise it uses internal IP address on local infra.