### PR TITLE
fix-docker-hub-base-image-name

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -48,9 +48,9 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
-          images: nutsfoundation/nuts-node
+          images: nutsfoundation/nuts-demo-ehr
           tags: |
-            # generate 'master' tag for the master branch
+            # generate 'main' tag for the main branch
             type=ref,event=branch,enable={{is_default_branch}},prefix=
             # generate 5.2.1 tag
             type=semver,pattern={{version}}


### PR DESCRIPTION
[Recently](https://github.com/nuts-foundation/nuts-demo-ehr/commit/1afe5155fd1cbb1f99e6db66274c19b1fe2cf6c8) the base image was changed from `nutsfoundation/nuts-demo-ehr` to `nutsfoundation/nuts-node` by mistake. This PR fixes that.

- who can remove the `nutsfoundation/nuts-node:main` tag on docker hub?
- is it ok for the different repo's to share one secret for docker hub?

